### PR TITLE
v1.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,9 +4,9 @@ org.gradle.parallel=true
 
 # Fabric Properties
 	# check these on https://fabricmc.net/develop
-	minecraft_version=1.20.4
-	yarn_mappings=1.20.4+build.3
-	loader_version=0.15.6
+minecraft_version=1.17
+yarn_mappings=1.17+build.13
+loader_version=0.15.11
 
 # Mod Properties
 	mod_version = 1.1

--- a/src/main/java/net/tape/LightsOut/main.java
+++ b/src/main/java/net/tape/LightsOut/main.java
@@ -3,25 +3,7 @@ package net.tape.LightsOut;
 
 import net.fabricmc.api.ModInitializer;
 
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public class main implements ModInitializer {
-	// This logger is used to write text to the console and the log file.
-	// It is considered best practice to use your mod id as the logger's name.
-	// That way, it's clear which mod wrote info, warnings, and errors.
-	public static final Logger LOGGER = LoggerFactory.getLogger("LightsOut");
-
 	@Override
-	public void onInitialize() {
-		// This code runs as soon as Minecraft is in a mod-load-ready state.
-		// However, some things (like resources) may still be uninitialized.
-		// Proceed with mild caution.
-
-
-
-		LOGGER.info("LightsOut successfully initialized.");
-
-	}
+	public void onInitialize() {}
 }

--- a/src/main/java/net/tape/LightsOut/mixin/RedstoneWallTorchMixin.java
+++ b/src/main/java/net/tape/LightsOut/mixin/RedstoneWallTorchMixin.java
@@ -1,0 +1,24 @@
+package net.tape.LightsOut.mixin;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.Slice;
+
+import java.util.function.ToIntFunction;
+
+@Mixin(Blocks.class)
+public class RedstoneWallTorchMixin {
+	@ModifyArg(method = "<clinit>",
+			at = @At(value = "INVOKE", target = "net/minecraft/block/AbstractBlock$Settings.luminance (Ljava/util/function/ToIntFunction;)Lnet/minecraft/block/AbstractBlock$Settings;", ordinal = 0),
+			slice = @Slice(
+					from = @At(value = "CONSTANT", args = "stringValue=redstone_wall_torch")
+			)
+	)
+
+	private static ToIntFunction<BlockState> foo(ToIntFunction<BlockState> x) {
+		return (state) -> 0;
+	}
+}

--- a/src/main/resources/LightsOut.mixins.json
+++ b/src/main/resources/LightsOut.mixins.json
@@ -4,7 +4,8 @@
   "package": "net.tape.LightsOut.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
-    "RedstoneTorchMixin"
+    "RedstoneTorchMixin",
+    "RedstoneWallTorchMixin"
   ],
   "client": [],
   "server": [],

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -29,7 +29,7 @@
 
   "depends": {
     "fabricloader": ">=0.14.21",
-    "minecraft": "~1.20",
+    "minecraft": ">=1.17",
     "java": ">=17"
   },
   "suggests": {}


### PR DESCRIPTION
updates some of the template copied over from TIMM, removes fabric api dependency, removes light emissions from redstone wall torches, now works on versions 1.17+ (tested on versions 1.17, 1.18, 1.20.4, and 1.21)